### PR TITLE
Fix by adding classic handling

### DIFF
--- a/src/lib/modes/directModeBezierOverride.js
+++ b/src/lib/modes/directModeBezierOverride.js
@@ -140,6 +140,13 @@ DirectModeBezierOverride.onMidpoint = function(state, e) {
     state.selectedCoordPaths = [newCoordPath];
     const selectedCoordinates = this.pathsToCoordinates(state.featureId, state.selectedCoordPaths);
     this.setSelectedCoordinates(selectedCoordinates);
+  } else {
+    // IF NOT A BEZIER GROUP : classic handling
+    this.startDragging(state, e);
+    const about = e.featureTarget.properties;
+    state.feature.addCoordinate(about.coord_path, about.lng, about.lat);
+    this.fireUpdate();
+    state.selectedCoordPaths = [about.coord_path];
   }
 };
 


### PR DESCRIPTION
* Fix without changing the plugin architecture, it just replicates code from the original onMidpoint at [mapbox-draw's direct_select mode](https://github.com/mapbox/mapbox-gl-draw/blob/0efdb4d14a0ecae37cfe467334aaa5b2e501f702/src/modes/direct_select.js#L57)